### PR TITLE
Update to Chrome Manifest V3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "Doujin Archive Filename Generator",
   "description": "A simple tool to generate filename when making game archive.",
-  "version": "0.0.1",
+  "version": "0.0.2",
 
   "content_scripts": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doujin-archive-filename-generator",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ A simple tool to generate filename when making game archive.
 4. Load extension through Chrome
 5. Open any DLsite doujin game page (currently only Japanese page supported.)
 
+This extension now uses Manifest V3 and requires a recent version of Chrome.
+
 Example here: [NSFW Warning!](https://www.dlsite.com/maniax/work/=/product_id/RJ162718.html)
 
 ## Screenshot


### PR DESCRIPTION
## Summary
- migrate `manifest.json` to Chrome manifest version 3
- bump extension version to 0.0.2
- document manifest v3 requirement

## Testing
- `yarn build` *(fails: package missing from lockfile)*
- `yarn install` *(fails: RequestError 403 due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_68526f27e2ec83319f2219b425d1ca4f